### PR TITLE
Update WPS compilation instructions for ex113

### DIFF
--- a/WPS/README.md
+++ b/WPS/README.md
@@ -3,14 +3,6 @@ Quick Start
 
 The WPS and WRF versions must be exactly the same. The script `compile_src_WPS.sh` is tested with WRF and WPS version 4.6.
 
-`PrgEnv-intel`:
-
-```
-cd build-recipes/WPS/
-./get_src_WPS.sh 4.6.0
-./compile_src_WPS.sh intel /scratch/$USER/WRF_install/wrf/intel/dmpar/WRF/ &> wps-compile-log.txt
-```
-
 `PrgEnv-gnu`:
 
 ```

--- a/WPS/compile_src_WPS.sh
+++ b/WPS/compile_src_WPS.sh
@@ -9,7 +9,7 @@ function usage() {
 }
 function get_code_install(){
 if [ $1 = gnu ]; then
-   echo "3"
+   echo "2"
 elif [ $1 = intel ]; then
    echo "43"
 elif [ $1 = cray ]; then
@@ -27,6 +27,7 @@ else
 fi
 if [ $compiler = gnu ]; then
    module sw PrgEnv-cray PrgEnv-gnu
+   config_parameters="--build-grib2-libs"
 elif [ $compiler = intel ]; then
    module sw PrgEnv-cray PrgEnv-intel
    module sw intel/2023.1.0 intel/2024.2.1
@@ -51,7 +52,7 @@ rm -rf $SRC_DIR
 mkdir -p $SRC_DIR
 cp -r WPS $SRC_DIR
 cd $SRC_DIR/WPS
-./configure <<< $(get_code_install $compiler)
+./configure ${config_parameters} <<< $(get_code_install $compiler)
 
 ## CPE WRAPPERS
 CONFIGURE_FILE=configure.wps


### PR DESCRIPTION
This PR updates the WPS compilation instructions for PrgEnv-gnu. It is tested with ex113 and cpe 25.03.